### PR TITLE
Fixed some elements of grabbable object physics

### DIFF
--- a/Assets/Scenes/TestingScenes/TestCamera.unity
+++ b/Assets/Scenes/TestingScenes/TestCamera.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.02978895, g: 0.017727647, b: 0.01999595, a: 1}
+  m_IndirectSpecularColor: {r: 0.029643869, g: 0.017717203, b: 0.019852372, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -525,8 +525,8 @@ Transform:
   m_GameObject: {fileID: 221347962}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -42.795, y: 34.679, z: -39.937}
-  m_LocalScale: {x: 0.1, y: 0.05, z: 0.1}
+  m_LocalPosition: {x: -38.11, y: 34.679, z: -39.937}
+  m_LocalScale: {x: 0.2, y: 0.1, z: 0.2}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -910,6 +910,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 102118944}
     - target: {fileID: 7135133530751734024, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7135133530751734024, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
       propertyPath: MAXCUBEDIST
       value: 5000
       objectReference: {fileID: 0}
@@ -924,6 +928,10 @@ PrefabInstance:
     - target: {fileID: 7135133530751734024, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
       propertyPath: grappleForce
       value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 7135133530751734024, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
+      propertyPath: grabbableDist
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7848632524417778751, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
       propertyPath: player
@@ -1974,6 +1982,91 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1989533824
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_Name
+      value: GrabbableTest
+      objectReference: {fileID: 0}
+    - target: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_TagString
+      value: Grabbable
+      objectReference: {fileID: 0}
+    - target: {fileID: 3175633078288224177, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_Drag
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3175633078288224177, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_Mass
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4865943961132617016, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4865943961132617016, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4865943961132617016, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4865943961132617016, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4865943961132617016, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 26.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 4865943961132617016, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -31.84
+      objectReference: {fileID: 0}
+    - target: {fileID: 4865943961132617016, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4865943961132617016, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4865943961132617016, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4865943961132617016, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4865943961132617016, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4865943961132617016, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4865943961132617016, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6019699281600177786, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 13400000, guid: d3420c2ddc2e8524295bae9b52747620, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
 --- !u!1 &2116380050 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6403545265453732062, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
@@ -2124,3 +2217,4 @@ SceneRoots:
   - {fileID: 9074081388130719481}
   - {fileID: 637273724}
   - {fileID: 221347966}
+  - {fileID: 1989533824}

--- a/Assets/Scripts/GrabScript.cs
+++ b/Assets/Scripts/GrabScript.cs
@@ -6,7 +6,7 @@ public class GrabScript : MonoBehaviour
 {
     public GameObject player;
     public Transform posHold;
-    public GameObject pickUpText;
+    //public GameObject pickUpText;
     private GameObject lookObject;
     private GameObject grabbedObject;
     private Rigidbody grabRigid;
@@ -21,12 +21,12 @@ public class GrabScript : MonoBehaviour
                 if (hit.transform.gameObject.tag == "Grabbable") {
                     lookObject = hit.transform.gameObject;
                     currLook = true;
-                    pickUpText.SetActive(true);
+                   // pickUpText.SetActive(true);
                 }
             } else {
                 lookObject = null;
                 currLook = false;
-                pickUpText.SetActive(false);
+               // pickUpText.SetActive(false);
             }
         }
         
@@ -52,7 +52,7 @@ public class GrabScript : MonoBehaviour
         grabRigid.transform.parent = posHold.transform;
         grabbedObject.transform.rotation = posHold.rotation;
         Physics.IgnoreCollision(grabbedObject.GetComponent<Collider>(), player.GetComponent<Collider>(), true);
-        pickUpText.SetActive(false);
+        //pickUpText.SetActive(false);
     }
 
     // Drops Object

--- a/Assets/Scripts/Grapple Head.cs
+++ b/Assets/Scripts/Grapple Head.cs
@@ -64,11 +64,12 @@ public class GrappleHead : MonoBehaviour
     {
         if (collision.gameObject.GetComponent<PlayerGrapple>() == null)
         {
+            
             if (!insideSomething && collision.gameObject.CompareTag("Grabbable")) { // Code for if the object was grabbable
                 grabbedObj = collision.gameObject;
                 grabRig = grabbedObj.GetComponent<Rigidbody>();
-                grabRig.isKinematic = true;
-                grabRig.transform.parent = rigidBody.transform;
+                grabRig.isKinematic = false;
+                //grabRig.transform.parent = rigidBody.transform;
                 // grabRig.transform.parent = rigidBody.transform;
 
                 rigidBody.isKinematic = true; //Disables Physics on this object
@@ -76,10 +77,11 @@ public class GrappleHead : MonoBehaviour
                 transform.parent = collision.transform;
                 insideSomething = true;
                 player.StartGrappling(collision.collider);
-
-                StopGrappling();
             }
-            else if (!insideSomething)
+           
+            
+            
+            if (!insideSomething)
             {
                 rigidBody.isKinematic = true; //Disables Physics on this object
                 GetComponent<Collider>().enabled = false;

--- a/Assets/Scripts/PlayerGrapple.cs
+++ b/Assets/Scripts/PlayerGrapple.cs
@@ -18,6 +18,9 @@ public class PlayerGrapple : MonoBehaviour
     private GameObject hand;
     float timer = -1.0f;
 
+    //Distance to a grabbable object
+    public float grabbableDist;
+
     //Hiding the camera's rigidbody with the one we want
     [SerializeField] private new Rigidbody rigidbody;
 
@@ -207,8 +210,17 @@ public class PlayerGrapple : MonoBehaviour
     private IEnumerator Grappling(Collider collider)
     {
         while (true) {
+            //If you are connected to a grabbable object, this checks your distance to it and automatically
+            //sets it to grabbed when it is close enough. It does this by running StopGrappling()
+            //in GrappleHead.cs
+            if (collider.CompareTag("Grabbable") && Vector3.Distance(this.transform.position, collider.transform.position) < 5)
+            {
+                Debug.Log("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+                grappleHead.StopGrappling();
+            }
+
             Vector3 moveVector = grappleHead.transform.position - transform.position;
-            if (collider.CompareTag("MoveableObject"))
+            if (collider.CompareTag("MoveableObject") || collider.CompareTag("Grabbable"))
             {
                 if(Vector3.Angle(rigidbody.velocity.normalized, moveVector.normalized) > dampingAngle)
                 {
@@ -230,11 +242,13 @@ public class PlayerGrapple : MonoBehaviour
                         rigidbody.velocity = rigidbody.velocity * (1 - dampingSpeed);
                     }
                     rigidbody.AddForce(moveVector.normalized * grappleForce);
+
                 }
                 else
                 {
                     goal.GetComponent<goal>().NextLevel();
                 }
+
             }
             else
             {


### PR DESCRIPTION
Grappling grabbable objects now causes the object and the player to move toward each other at a more usable speed.

Fixed:
-The grappling hook was not fully retracting when acting on a grabbable object due to a missing asset.
-Issues affecting the physics

Still need:
-Proper prefab for grabbable objects, and to ensure that these objects work as intended with both manual grabbing and grabbing with the grappling hook
-An asset for the pick up and drop messages

Do note that the following bugs still exist:
-The grappling hook's animation is bugged when grappling to a small object. I believe this bug already existed but had not showed itself yet.
-When holding a grabbed object, the crosshair cube often does not work as intended. (Doesn't properly follow direction player is looking)